### PR TITLE
setup.py: Exclude tests from runtime package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include *.md
+include LICENSE
+recursive-include tests *.py
+recursive-include tests *.json *.toml *.yml *.plist

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     description='Consistent CLI config file modifier',
     long_description=long_description,
     long_description_content_type="text/markdown",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests*"]),
     url='https://github.com/astzweig/cocof-py',
     keywords=['toml', 'yaml', 'json', 'terminal', 'cli', 'edit'],
     classifiers=[


### PR DESCRIPTION
Add MANIFEST.in to add tests to the sdist only.